### PR TITLE
LHTNG-3595 - In some flows at_hash is not included in the id_token.  …

### DIFF
--- a/lib/oidc-client.js
+++ b/lib/oidc-client.js
@@ -421,13 +421,16 @@ OidcClient.prototype = {
     var self = this;
 
     return self.validateIdTokenAsync(id_token, nonce, access_token).then(function (id_token_contents) {
-
-      return self.validateAccessTokenFromIdTokenHashAsync(id_token_contents, access_token).then(function () {
-
+      let validateAccessToken;
+      if(id_token_contents.at_hash){
+        validateAccessToken = self.validateAccessTokenFromIdTokenHashAsync(id_token_contents, access_token);
+      }
+      else {
+        validateAccessToken = self.validateAccessTokenAsync(access_token);
+      }
+      return validateAccessToken.then(function() {
         return id_token_contents;
-
       });
-
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-client-node-overdrive",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenID Connect (OIDC) node.js library customized for Overdrive's use case",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
…Use it for validation when present, otherwise fall back on standalone access token validation.